### PR TITLE
chore: Update CLI tool to support nested folder structure and version bump to 1.0.6

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "MD013": false,
+  "MD024": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,9 @@
 {
-    "chat.tools.terminal.autoApprove": {
-        "mkdir": true
-    }
+  "chat.tools.terminal.autoApprove": {
+    "mkdir": true
+  },
+  "[markdown]": {
+    "editor.formatOnSave": true,
+    "editor.formatOnPaste": true,
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the Programming Languages and Frameworks Agent Skills wil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [cli-v1.0.6] - 2026-01-17
+
+**Category**: CLI Tool
+
+### Improved
+
+- Switched to a nested folder structure (e.g., `skills/flutter/bloc`) for better organization and scalability, replacing the previous flat structure (`skills/flutter-bloc`).
+- Enhanced Security: Replaced all `execSync` calls with `execFileSync` to prevent potential command injection vulnerabilities (CWE-78/CWE-88).
+
+### Fixed
+
+- Documentation updates to reflect the new nested directory structure.
+
 ## [cli-v1.0.5] - 2026-01-17
 
 **Category**: CLI Tool

--- a/README.md
+++ b/README.md
@@ -106,10 +106,18 @@ The standard follows a strict directory structure designed for **Token Economy**
 
 ```text
 skills/
+└── flutter/                        # Category
+    └── bloc-state-management/      # Skill
+        ├── SKILL.md                # Core Rules (High Density)
+        └── references/             # Heavy Examples (Loaded only on demand)
+```
+
+The CLI will sync this exact structure effectively to your agent configuration:
+
+```text
+.cursor/skills/
 └── flutter/
     └── bloc-state-management/
-        ├── SKILL.md       # Core Rules (High Density)
-        └── references/    # Heavy Examples (Loaded only on demand)
 ```
 
 ### IDE Mapping

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-standard",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A CLI to manage and sync AI agent skills standard for Cursor, Claude, Copilot, and more.",
   "main": "dist/index.js",
   "bin": {

--- a/cli/src/commands/sync.ts
+++ b/cli/src/commands/sync.ts
@@ -347,8 +347,8 @@ export class SyncCommand {
         await fs.ensureDir(basePath);
 
         for (const skill of skills) {
-          const skillFolderName = `${skill.category}-${skill.skill}`;
-          const skillPath = path.join(basePath, skillFolderName);
+          // Use nested structure: category/skill (e.g. flutter/bloc)
+          const skillPath = path.join(basePath, skill.category, skill.skill);
           await fs.ensureDir(skillPath);
 
           for (const fileItem of skill.files) {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -10,7 +10,7 @@ program
   .description(
     'A CLI to manage and sync AI agent skills for Cursor, Claude, Copilot, and more.',
   )
-  .version('1.0.5');
+  .version('1.0.6');
 
 program
   .command('init')


### PR DESCRIPTION
# 🚀 Pull Request

## 🔍 Root Cause

- Skills folder using flat which make it quite messy when skills have lots

### 🔗 Last Related PR

- N/A

### 💡 Solution

- Update CLI tool to support nested folder structure