### PR TITLE
chore: Update CLI tool naming and references to 'agent-skills-standard'

### DIFF
--- a/.agent/instructions.md
+++ b/.agent/instructions.md
@@ -7,7 +7,7 @@ You are the maintainer of the Agent Skills Standard repository and CLI tool.
 - **Repo Type:** Hybrid (TypeScript CLI Tool + Markdown Skill Registry).
 - **Goal:** Distribute high-density coding instructions to AI agents.
 - **Components:**
-  - `cli/`: Source code for the `agent-skills` NPM package.
+  - `cli/`: Source code for the `agent-skills-standard` NPM package.
   - `skills/`: The source of truth for all distributed skills (Flutter, Dart, etc.).
 
 ## 🛠 Tech Stack & Conventions

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,7 +7,7 @@ You are the maintainer of the Agent Skills Standard repository and CLI tool.
 - **Repo Type:** Hybrid (TypeScript CLI Tool + Markdown Skill Registry).
 - **Goal:** Distribute high-density coding instructions to AI agents.
 - **Components:**
-  - `cli/`: Source code for the `agent-skills` NPM package.
+  - `cli/`: Source code for the `agent-skills-standard` NPM package.
   - `skills/`: The source of truth for all distributed skills (Flutter, Dart, etc.).
 
 ## 🛠 Tech Stack & Conventions

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,6 +102,6 @@ jobs:
 
             Checkout the changelog or sync in your project:
             ```bash
-            agent-skills sync
+            agent-skills-standard sync
             ```
           generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Programming Languages and Frameworks Agent Skills wil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [cli-v1.0.7] - 2026-01-17
+
+**Category**: CLI Tool
+
+### Added
+
+- Introduced `ags` as a short alias for the `agent-skills-standard` command for easier usage (e.g., `ags sync`).
+
 ## [cli-v1.0.6] - 2026-01-17
 
 **Category**: CLI Tool

--- a/SYNC_WORKFLOW.md
+++ b/SYNC_WORKFLOW.md
@@ -1,10 +1,10 @@
 # CLI Sync Workflow Documentation
 
-This document explains how to use the `agent-skills` CLI to automatically sync Flutter and Dart agent skills from the central repository to your project.
+This document explains how to use the `agent-skills-standard` CLI to automatically sync Flutter and Dart agent skills from the central repository to your project.
 
 ## Overview
 
-The `agent-skills` CLI provides automated version management for agent skills, allowing teams to:
+The `agent-skills-standard` CLI provides automated version management for agent skills, allowing teams to:
 
 - Initialize project-specific skill configurations.
 - Sync specific versions of skills using Git tags.
@@ -21,10 +21,10 @@ The CLI can be run directly via `npx` or installed globally:
 
 ```bash
 # Run without installation
-npx agent-skills <command>
+npx agent-skills-standard <command>
 
 # Or install globally
-npm install -g agent-skills
+npm install -g agent-skills-standard
 ```
 
 ### 2. Initialization
@@ -32,7 +32,7 @@ npm install -g agent-skills
 To start using the standard in your project, run the `init` command. This will create a `.skillsrc` file in your root directory.
 
 ```bash
-agent-skills init
+agent-skills-standard init
 ```
 
 The CLI will ask you:
@@ -74,7 +74,7 @@ skills:
 
 ## CLI Sync Behavior
 
-When you run `agent-skills sync`, the tool follows a **Selective Sync** strategy.
+When you run `agent-skills-standard sync`, the tool follows a **Selective Sync** strategy.
 
 ### 1. Progressive Disclosure (Token Efficiency)
 
@@ -90,12 +90,12 @@ Agents load `SKILL.md` automatically. They only read the `references/` if the co
 
 The CLI automatically maps registry folders to agent-specific hidden directories:
 
-| Agent | Output Path |
-| :--- | :--- |
-| **Antigravity** | `.agent/skills/external/` |
-| **Cursor** | `.cursor/skills/` |
-| **GitHub Copilot** | `.github/skills/` |
-| **Claude Code** | `.claude/skills/` |
+| Agent              | Output Path               |
+| :----------------- | :------------------------ |
+| **Antigravity**    | `.agent/skills/external/` |
+| **Cursor**         | `.cursor/skills/`         |
+| **GitHub Copilot** | `.github/skills/`         |
+| **Claude Code**    | `.claude/skills/`         |
 
 ### 3. Step-by-Step Logic
 
@@ -113,7 +113,7 @@ The CLI is designed to coexist with your own custom skills.
 
 ### 1. Merging with Existing Skills
 
-The `agent-skills sync` command **adds** folders to your agent's skills directory. It does not delete or "wipe" your existing custom skills.
+The `agent-skills-standard sync` command **adds** folders to your agent's skills directory. It does not delete or "wipe" your existing custom skills.
 
 - If you have a custom folder `.cursor/skills/my-project-specific-rules/`, it will remain untouched.
 - If you have a folder that matches a registry skill name (e.g., `flutter-performance`), only the files we manage (`SKILL.md`, `references/`, etc.) will be updated.
@@ -126,7 +126,7 @@ If there are specific files or entire skill folders managed by the registry that
 custom_overrides:
   # Protect a single file
   - .cursor/skills/flutter-bloc-state-management/SKILL.md
-  
+
   # Protect an entire skill folder (and all its references)
   - .cursor/skills/flutter-performance/
 ```
@@ -140,7 +140,7 @@ The sync tool will skip any file or directory listed in this array, allowing you
 ### Initialize a Project
 
 ```bash
-$ agent-skills init
+$ agent-skills-standard init
 
 ? Select AI Agents to support: Cursor, GitHub Copilot
 ? Enable Flutter skills? Yes
@@ -154,7 +154,7 @@ $ agent-skills init
 ### Sync Skills
 
 ```bash
-$ agent-skills sync
+$ agent-skills-standard sync
 
 🚀 Syncing skills from https://github.com/HoangNguyen0403/agent-skills-standard...
   - Discovering flutter skills via GitHub API (flutter-v1.0.0)...
@@ -208,7 +208,7 @@ Tags in the registry follow the `semver` standard combined with the category:
 
 ### `Error: .skillsrc not found`
 
-Run `agent-skills init` first to generate the configuration.
+Run `agent-skills-standard init` first to generate the configuration.
 
 ### `Failed to fetch remote skills (Status: 404)`
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -43,6 +43,9 @@ npx agent-skills-standard sync
 
 # Or install globally
 npm install -g agent-skills-standard
+
+# Use the short alias
+ags sync
 ```
 
 ---

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,10 +1,11 @@
 {
   "name": "agent-skills-standard",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A CLI to manage and sync AI agent skills standard for Cursor, Claude, Copilot, and more.",
   "main": "dist/index.js",
   "bin": {
-    "agent-skills-standard": "dist/index.js"
+    "agent-skills-standard": "dist/index.js",
+    "ags": "dist/index.js"
   },
   "files": [
     "dist"

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -214,7 +214,9 @@ export class InitCommand {
       ),
     );
     console.log(
-      pc.cyan('\nNext step: Run `agent-skills sync` to generate rule files.'),
+      pc.cyan(
+        '\nNext step: Run `agent-skills-standard sync` to generate rule files.',
+      ),
     );
   }
 }

--- a/cli/src/commands/sync.ts
+++ b/cli/src/commands/sync.ts
@@ -39,7 +39,7 @@ export class SyncCommand {
       console.log(
         pc.red('❌ Error: .skillsrc not found in current directory.'),
       );
-      console.log(pc.yellow('Run `agent-skills init` first.'));
+      console.log(pc.yellow('Run `agent-skills-standard init` first.'));
       return;
     }
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -6,7 +6,7 @@ import { SyncCommand } from './commands/sync';
 const program = new Command();
 
 program
-  .name('agent-skills')
+  .name('agent-skills-standard')
   .description(
     'A CLI to manage and sync AI agent skills for Cursor, Claude, Copilot, and more.',
   )


### PR DESCRIPTION
# 🚀 Pull Request

## 🔍 Root Cause

- package name is quite long for typing
- the instruction text for npm package is not up-to-date

### 🔗 Last Related PR

- N/A

### 💡 Solution

- chore: Update CLI tool naming and references to 'agent-skills-standard'