### PR TITLE
ci: Tessl skill review + optimize on SKILL.md PRs

### DIFF
--- a/.github/workflows/skill-apply-optimize.yml
+++ b/.github/workflows/skill-apply-optimize.yml
@@ -1,0 +1,24 @@
+# Comment `/apply-optimize` on a PR to commit suggested optimizations from the review workflow.
+# Pairs with skill-review.yml (tesslio/skill-review-and-optimize).
+name: Apply Skill Optimization
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  apply:
+    if: >-
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/apply-optimize')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.issue.pull_request.head.ref }}
+      - uses: tesslio/skill-review-and-optimize@d81583861aaf29d1da7f10e6539efef4e27b0dd5
+        with:
+          mode: "apply"

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,23 @@
+# Tessl skill review + optional AI optimization suggestions on SKILL.md PRs.
+# Superset of tesslio/skill-review; uses TESSL_API_TOKEN for optimize. See:
+# https://github.com/giuseppe-trisciuoglio/developer-kit/pull/160
+name: Skill Review & Optimize
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review-and-optimize@d81583861aaf29d1da7f10e6539efef4e27b0dd5
+        with:
+          optimize: "true"
+          tessl-token: ${{ secrets.TESSL_API_TOKEN }}


### PR DESCRIPTION
## Hey @HoangNguyen0403 👋

This builds on the skill-quality work from [#68](https://github.com/HoangNguyen0403/agent-skills-standard/pull/68) by adding **CI automation** so future PRs that touch `**/SKILL.md`** get Tessl review and optional optimization suggestions

### What this adds

**`.github/workflows/skill-review.yml`**
- Triggers on PRs to **`main` and `develop`** when any `**/SKILL.md`** changes (aligned with your existing `ci.yml` branch list)
- Uses [`tesslio/skill-review-and-optimize`](https://github.com/tesslio/skill-review-and-optimize) (SHA-pinned): scores + feedback, plus **optimization suggestions** in a collapsible PR comment
- Requires repository secret **`TESSL_API_TOKEN`**

**`.github/workflows/skill-apply-optimize.yml`**
- Comment **`/apply-optimize`** on a PR to **commit** suggested optimizations to the PR branch

This complements your lint/format CI — it does not replace `pnpm` checks or the token-economy rules in `CONTRIBUTING.md`; it only automates Tessl feedback on skill markdown.

### Maintainer setup

Add **Settings → Secrets → `TESSL_API_TOKEN`** with a Tessl API token.

### Disclosure

Honest disclosure — I work at [@tesslio](https://github.com/tesslio) where we build tooling around agent skills.

Thanks in advance 🙏
