### PR TITLE
fix: update changelog for version 2.1.1 and enhance IndexGeneratorSer…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,20 @@ All notable changes to the Programming Languages and Frameworks Agent Skills wil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.0] - 2026-04-04
+## [2.1.1] - 2026-04-04
 
-**Category**: Hierarchical Skill Resolution & Three-Tier Trigger Model & Tessl Quality Audit
+**Category**: Fix Hierarchical Index Sync
+
+### Fixed
+
+- **CLI metadata sync**: Fixed an issue where `ags sync` failed to populate the hierarchical router table in `AGENTS.md`. The `IndexGeneratorService` now uses an in-memory `RemoteMetadata` injection system to fetch `skills/metadata.json` directly from the registry without writing it to the user's disk.
+- **Index Generation**: Added `withMetadata()` to `IndexGeneratorService` to allow injecting `file_routing`, `broad_globs`, and `base_language_skills` at runtime during a sync operation.
+
+### Versions
+
+- **CLI**: v2.1.1 (Patch — fix metadata injection during sync)
+
+## [2.1.0] - 2026-04-04
 
 ### Added
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-standard",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A CLI to manage and sync AI agent skills standard for Cursor, Claude, Copilot, Windsurf, and more.",
   "main": "dist/index.js",
   "bin": {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -18,7 +18,7 @@ program
   .description(
     'A CLI to manage and sync AI agent skills for Cursor, Claude, Copilot, Windsurf, and more.',
   )
-  .version('2.1.0');
+  .version('2.1.1');
 
 program
   .command('init')

--- a/cli/src/services/IndexGeneratorService.ts
+++ b/cli/src/services/IndexGeneratorService.ts
@@ -4,6 +4,18 @@ import path from 'path';
 import { INJECTION_PATTERNS } from '../constants/security';
 
 /**
+ * Subset of the registry's metadata.json that the IndexGeneratorService needs at
+ * index-generation time. Provided by the caller (e.g. SyncService) so the file
+ * never needs to be written to disk inside the user's project.
+ */
+export interface RemoteMetadata {
+  file_routing?: Record<string, string[]>;
+  broad_globs?: string[];
+  base_language_skills?: Record<string, string>;
+  foundational_composite_rules?: Record<string, string[]>;
+}
+
+/**
  * Metadata structure for a skill, extracted from the frontmatter and content of a SKILL.md file.
  */
 export interface SkillMetadata {
@@ -37,13 +49,27 @@ export interface SkillMetadata {
  * Injection and bridging are handled by MarkdownUtils and AgentBridgeService respectively.
  */
 export class IndexGeneratorService {
+  private remoteMetadata?: RemoteMetadata;
+
   /**
-   * Loads foundational composite rules from the registry's metadata.json.
-   * Falls back to an empty map if the file is missing or malformed.
+   * Injects registry metadata so index generation does not require metadata.json
+   * to be present on disk. Returns `this` for chaining.
+   */
+  withMetadata(metadata: RemoteMetadata): this {
+    this.remoteMetadata = metadata;
+    return this;
+  }
+
+  /**
+   * Loads foundational composite rules. Uses injected remote metadata when available;
+   * falls back to reading metadata.json from baseDir.
    */
   private async loadFoundationalRules(
     baseDir: string,
   ): Promise<Record<string, string[]>> {
+    if (this.remoteMetadata?.foundational_composite_rules !== undefined) {
+      return this.remoteMetadata.foundational_composite_rules;
+    }
     try {
       const metaPath = path.join(baseDir, 'metadata.json');
       const raw = await fs.readFile(metaPath, 'utf8');
@@ -177,12 +203,15 @@ export class IndexGeneratorService {
   }
 
   /**
-   * Loads file routing rules from the registry's metadata.json.
-   * Maps file extensions to category arrays for router table generation.
+   * Loads file routing rules. Uses injected remote metadata when available;
+   * falls back to reading metadata.json from baseDir.
    */
   private async loadFileRouting(
     baseDir: string,
   ): Promise<Record<string, string[]>> {
+    if (this.remoteMetadata?.file_routing !== undefined) {
+      return this.remoteMetadata.file_routing;
+    }
     try {
       const metaPath = path.join(baseDir, 'metadata.json');
       const raw = await fs.readFile(metaPath, 'utf8');
@@ -196,13 +225,19 @@ export class IndexGeneratorService {
   }
 
   /**
-   * Loads broad glob patterns and base language skill mappings from metadata.json.
-   * Used to classify triggers into tiers (file match vs keyword match).
+   * Loads broad glob patterns and base language skill mappings. Uses injected remote
+   * metadata when available; falls back to reading metadata.json from baseDir.
    */
   private async loadTierConfig(baseDir: string): Promise<{
     broadGlobs: string[];
     baseSkills: Record<string, string>;
   }> {
+    if (this.remoteMetadata !== undefined) {
+      return {
+        broadGlobs: this.remoteMetadata.broad_globs ?? [],
+        baseSkills: this.remoteMetadata.base_language_skills ?? {},
+      };
+    }
     try {
       const metaPath = path.join(baseDir, 'metadata.json');
       const raw = await fs.readFile(metaPath, 'utf8');

--- a/cli/src/services/SyncService.ts
+++ b/cli/src/services/SyncService.ts
@@ -97,6 +97,31 @@ export class SyncService {
 
       const allowedCategories = Object.keys(config.skills || {});
 
+      // Fetch metadata.json from the registry's default branch and inject it into the
+      // generator in-memory. This gives assembleRouterIndex the file_routing, broad_globs,
+      // and base_language_skills it needs without writing anything to disk.
+      const githubMatch = config.registry
+        ? GithubService.parseGitHubUrl(config.registry)
+        : null;
+      if (githubMatch) {
+        const { owner, repo } = githubMatch;
+        const repoInfo = await this.githubService.getRepoInfo(owner, repo);
+        const ref = repoInfo?.default_branch || 'main';
+        const metaRaw = await this.githubService.getRawFile(
+          owner,
+          repo,
+          ref,
+          'skills/metadata.json',
+        );
+        if (metaRaw) {
+          try {
+            generator.withMetadata(JSON.parse(metaRaw));
+          } catch {
+            // Malformed JSON — continue without remote metadata; router falls back to file
+          }
+        }
+      }
+
       // Generate per-category _INDEX.md files for all target agents
       const categoryIndices = await generator.generateAllCategoryIndices(
         baseDir,

--- a/cli/src/services/__tests__/IndexGeneratorService.spec.ts
+++ b/cli/src/services/__tests__/IndexGeneratorService.spec.ts
@@ -740,4 +740,208 @@ describe('IndexGeneratorService', () => {
       stderrSpy.mockRestore();
     });
   });
+
+  describe('withMetadata injection', () => {
+    // Helper: mock the agent skill directory to contain only the specified category folders.
+    function mockAgentDir(categories: string[]) {
+      (fs.pathExists as any).mockImplementation(
+        async (p: string) =>
+          categories.some((c) => p.includes(c)) || p === '/agent/skills',
+      );
+      (fs.readdir as any).mockImplementation(async (p: string) => {
+        if (p === '/agent/skills') return categories;
+        return [];
+      });
+    }
+
+    it('uses injected file_routing instead of reading metadata.json from disk', async () => {
+      mockAgentDir(['golang', 'common']);
+
+      // No metadata.json on disk — file reads for it should NOT be reached
+      (fs.readFile as any).mockRejectedValue(new Error('ENOENT'));
+
+      service.withMetadata({
+        file_routing: { go: ['golang'] },
+      });
+
+      const result = await service.assembleRouterIndex('/agent/skills');
+
+      expect(result).toContain('`*.go`');
+      expect(result).toContain('golang/_INDEX.md');
+      expect(result).toContain('common/_INDEX.md');
+    });
+
+    it('only includes routing rows for categories the user actually has installed', async () => {
+      // User only has golang and common — not typescript, react, nextjs
+      mockAgentDir(['golang', 'common']);
+
+      (fs.readFile as any).mockRejectedValue(new Error('ENOENT'));
+
+      service.withMetadata({
+        file_routing: {
+          go: ['golang'],
+          ts: ['typescript', 'react', 'nextjs'],
+          tsx: ['react', 'nextjs'],
+        },
+      });
+
+      const result = await service.assembleRouterIndex('/agent/skills');
+
+      expect(result).toContain('`*.go`');
+      expect(result).toContain('golang/_INDEX.md');
+      // typescript / react / nextjs are not installed → their rows must be absent
+      expect(result).not.toContain('typescript/_INDEX.md');
+      expect(result).not.toContain('react/_INDEX.md');
+      expect(result).not.toContain('nextjs/_INDEX.md');
+      expect(result).not.toContain('`*.ts`');
+      expect(result).not.toContain('`*.tsx`');
+    });
+
+    it('shows a partial row when only some categories in a routing entry are installed', async () => {
+      // typescript is installed, but react and nextjs are not
+      mockAgentDir(['typescript', 'common']);
+
+      (fs.readFile as any).mockRejectedValue(new Error('ENOENT'));
+
+      service.withMetadata({
+        file_routing: {
+          ts: ['typescript', 'react', 'nextjs'],
+        },
+      });
+
+      const result = await service.assembleRouterIndex('/agent/skills');
+
+      expect(result).toContain('`*.ts`');
+      expect(result).toContain('typescript/_INDEX.md');
+      expect(result).not.toContain('react/_INDEX.md');
+      expect(result).not.toContain('nextjs/_INDEX.md');
+    });
+
+    it('produces only catch-all rows when no routing category is installed', async () => {
+      // User has only quality-engineering, which is not in file_routing
+      mockAgentDir(['quality-engineering', 'common']);
+
+      (fs.readFile as any).mockRejectedValue(new Error('ENOENT'));
+
+      service.withMetadata({
+        file_routing: {
+          go: ['golang'],
+          ts: ['typescript'],
+        },
+      });
+
+      const result = await service.assembleRouterIndex('/agent/skills');
+
+      // No file-extension rows
+      expect(result).not.toContain('`*.go`');
+      expect(result).not.toContain('`*.ts`');
+      // But the catch-all rows must still be present
+      expect(result).toContain('common/_INDEX.md');
+      expect(result).toContain('quality-engineering/_INDEX.md');
+    });
+
+    it('uses injected broad_globs and base_language_skills for tier classification', async () => {
+      (fs.pathExists as any).mockImplementation(
+        async (p: string) => p.includes('golang') || p.includes('SKILL.md'),
+      );
+      (fs.readdir as any).mockImplementation(async (p: string) => {
+        if (p.endsWith('golang')) return ['golang-language', 'golang-testing'];
+        return [];
+      });
+
+      // No metadata.json on disk
+      (fs.readFile as any).mockImplementation(async (p: string) => {
+        if (p.includes('metadata.json')) throw new Error('ENOENT');
+        if (p.includes('golang-language')) {
+          return '---\nname: golang-language\ndescription: Core\nmetadata:\n  triggers:\n    files: ["**/*.go"]\n    keywords: [golang]\n---\n## **Priority: P1**';
+        }
+        return '---\nname: golang-testing\ndescription: Tests\nmetadata:\n  triggers:\n    files: ["**/*_test.go"]\n    keywords: [testing]\n---\n## **Priority: P1**';
+      });
+      (yaml.load as any).mockImplementation((c: string) =>
+        c.includes('golang-language')
+          ? {
+              name: 'golang-language',
+              description: 'Core',
+              metadata: {
+                triggers: { files: ['**/*.go'], keywords: ['golang'] },
+              },
+            }
+          : {
+              name: 'golang-testing',
+              description: 'Tests',
+              metadata: {
+                triggers: { files: ['**/*_test.go'], keywords: ['testing'] },
+              },
+            },
+      );
+
+      // Inject tier config — golang-language is the base skill so broad glob stays in File Match
+      service.withMetadata({
+        broad_globs: ['**/*.go'],
+        base_language_skills: { golang: 'golang-language' },
+      });
+
+      const result = await service.generateCategoryIndex(
+        '/agent/skills',
+        'golang',
+      );
+
+      // Base skill keeps broad glob in File Match
+      expect(result).toContain('## File Match');
+      expect(result).toContain('golang-language');
+      // Non-base specific glob also in File Match
+      expect(result).toContain('golang-testing');
+    });
+
+    it('uses injected foundational_composite_rules for generate()', async () => {
+      (fs.pathExists as any).mockResolvedValue(false);
+      // No metadata.json on disk — must not be read
+      (fs.readFile as any).mockRejectedValue(new Error('ENOENT'));
+
+      service.withMetadata({
+        foundational_composite_rules: {
+          'common/security-standards': ['security'],
+        },
+      });
+
+      // generate() will return header even with empty baseDir — just confirm no throw
+      const result = await service.generate('/agent/skills');
+      expect(result).toContain('## Agent Skills Index');
+    });
+
+    it('falls back to file-based metadata when withMetadata is not called', async () => {
+      (fs.pathExists as any).mockResolvedValue(true);
+      (fs.readdir as any).mockImplementation(async (p: string) => {
+        if (p === '/agent/skills') return ['golang', 'common'];
+        return [];
+      });
+      (fs.readFile as any).mockImplementation(async (p: string) => {
+        if (p.includes('metadata.json')) {
+          return JSON.stringify({ file_routing: { go: ['golang'] } });
+        }
+        return '';
+      });
+
+      // No withMetadata() call — should read from disk
+      const fresh = new IndexGeneratorService();
+      const result = await fresh.assembleRouterIndex('/agent/skills');
+
+      expect(result).toContain('`*.go`');
+      expect(result).toContain('golang/_INDEX.md');
+    });
+
+    it('gracefully handles malformed remoteMetadata (missing keys)', async () => {
+      mockAgentDir(['common']);
+      (fs.readFile as any).mockRejectedValue(new Error('ENOENT'));
+
+      // Inject metadata with no file_routing at all
+      service.withMetadata({});
+
+      const result = await service.assembleRouterIndex('/agent/skills');
+
+      // No extension rows, but catch-all must still be rendered
+      expect(result).toContain('## Agent Skills Index');
+      expect(result).toContain('common/_INDEX.md');
+    });
+  });
 });

--- a/cli/src/services/__tests__/SyncService.spec.ts
+++ b/cli/src/services/__tests__/SyncService.spec.ts
@@ -29,6 +29,7 @@ describe('SyncService', () => {
 
     // Setup IndexGeneratorService mock implementation
     vi.mocked(IndexGeneratorService).mockImplementation(function (this: any) {
+      this.withMetadata = vi.fn().mockReturnThis();
       this.generate = vi.fn().mockResolvedValue('index content');
       this.assembleIndex = vi.fn().mockReturnValue('index content');
       this.generateAllCategoryIndices = vi.fn().mockResolvedValue({});
@@ -199,6 +200,7 @@ describe('SyncService', () => {
       vi.mocked(IndexGeneratorService).mockImplementationOnce(function (
         this: any,
       ) {
+        this.withMetadata = vi.fn().mockReturnThis();
         this.generateAllCategoryIndices = vi
           .fn()
           .mockRejectedValue(new Error('Gen failed'));
@@ -210,6 +212,156 @@ describe('SyncService', () => {
       expect(console.log).toHaveBeenCalledWith(
         expect.stringContaining('Failed to update index'),
       );
+    });
+
+    it('fetches metadata from registry main branch and injects it into the generator', async () => {
+      const remoteMetadata = {
+        file_routing: { go: ['golang'], ts: ['typescript'] },
+        broad_globs: ['**/*.go', '**/*.ts'],
+        base_language_skills: { golang: 'golang-language' },
+      };
+
+      mockGithubService.getRepoInfo.mockResolvedValue({
+        default_branch: 'main',
+      });
+      mockGithubService.getRawFile.mockResolvedValue(
+        JSON.stringify(remoteMetadata),
+      );
+
+      let capturedWithMetadata: any;
+      vi.mocked(IndexGeneratorService).mockImplementationOnce(function (
+        this: any,
+      ) {
+        this.withMetadata = vi.fn().mockImplementation((m: any) => {
+          capturedWithMetadata = m;
+          return this;
+        });
+        this.generateAllCategoryIndices = vi.fn().mockResolvedValue({});
+        this.assembleRouterIndex = vi.fn().mockResolvedValue('router');
+        return this;
+      } as any);
+
+      const config = {
+        registry: 'https://github.com/o/r',
+        agents: [Agent.Cursor],
+        skills: { golang: { ref: 'v1' }, typescript: { ref: 'v1' } },
+      } as any;
+
+      await syncService.applyIndices(config, [Agent.Cursor]);
+
+      // getRawFile must be called for skills/metadata.json (not checkForUpdates path)
+      expect(mockGithubService.getRawFile).toHaveBeenCalledWith(
+        'o',
+        'r',
+        'main',
+        'skills/metadata.json',
+      );
+      // withMetadata must receive the parsed remote metadata
+      expect(capturedWithMetadata).toEqual(remoteMetadata);
+    });
+
+    it('does NOT write metadata.json to disk', async () => {
+      mockGithubService.getRepoInfo.mockResolvedValue({
+        default_branch: 'main',
+      });
+      mockGithubService.getRawFile.mockResolvedValue(
+        JSON.stringify({ file_routing: { go: ['golang'] } }),
+      );
+
+      const config = {
+        registry: 'https://github.com/o/r',
+        agents: [Agent.Cursor],
+        skills: { golang: { ref: 'v1' } },
+      } as any;
+
+      await syncService.applyIndices(config, [Agent.Cursor]);
+
+      // fs.outputFile must never be called with metadata.json
+      const outputFileCalls = vi
+        .mocked(fs.outputFile as any)
+        .mock.calls.filter((args: any[]) =>
+          String(args[0]).includes('metadata.json'),
+        );
+      expect(outputFileCalls).toHaveLength(0);
+    });
+
+    it('continues gracefully when registry metadata fetch returns null', async () => {
+      mockGithubService.getRepoInfo.mockResolvedValue({
+        default_branch: 'main',
+      });
+      mockGithubService.getRawFile.mockResolvedValue(null);
+
+      let withMetadataCalled = false;
+      vi.mocked(IndexGeneratorService).mockImplementationOnce(function (
+        this: any,
+      ) {
+        this.withMetadata = vi.fn().mockImplementation(() => {
+          withMetadataCalled = true;
+          return this;
+        });
+        this.generateAllCategoryIndices = vi.fn().mockResolvedValue({});
+        this.assembleRouterIndex = vi.fn().mockResolvedValue('router');
+        return this;
+      } as any);
+
+      const config = {
+        registry: 'https://github.com/o/r',
+        agents: [Agent.Cursor],
+        skills: {},
+      } as any;
+
+      await syncService.applyIndices(config, [Agent.Cursor]);
+
+      // withMetadata should NOT have been called — no metadata to inject
+      expect(withMetadataCalled).toBe(false);
+      // But index generation still proceeds
+      expect(MarkdownUtils.injectIndex).toHaveBeenCalled();
+    });
+
+    it('continues gracefully when registry URL is invalid (no github match)', async () => {
+      const config = {
+        registry: 'not-a-github-url',
+        agents: [Agent.Cursor],
+        skills: {},
+      } as any;
+
+      // Should not throw and should still produce an index
+      await syncService.applyIndices(config, [Agent.Cursor]);
+
+      expect(MarkdownUtils.injectIndex).toHaveBeenCalled();
+      expect(mockGithubService.getRawFile).not.toHaveBeenCalled();
+    });
+
+    it('continues gracefully when registry metadata JSON is malformed', async () => {
+      mockGithubService.getRepoInfo.mockResolvedValue({
+        default_branch: 'main',
+      });
+      mockGithubService.getRawFile.mockResolvedValue('{ invalid json %%%');
+
+      let withMetadataCalled = false;
+      vi.mocked(IndexGeneratorService).mockImplementationOnce(function (
+        this: any,
+      ) {
+        this.withMetadata = vi.fn().mockImplementation(() => {
+          withMetadataCalled = true;
+          return this;
+        });
+        this.generateAllCategoryIndices = vi.fn().mockResolvedValue({});
+        this.assembleRouterIndex = vi.fn().mockResolvedValue('router');
+        return this;
+      } as any);
+
+      const config = {
+        registry: 'https://github.com/o/r',
+        agents: [Agent.Cursor],
+        skills: {},
+      } as any;
+
+      await syncService.applyIndices(config, [Agent.Cursor]);
+
+      // Malformed JSON → withMetadata skipped, but sync continues
+      expect(withMetadataCalled).toBe(false);
+      expect(MarkdownUtils.injectIndex).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
This pull request introduces a patch release (`2.1.1`) that fixes hierarchical index synchronization by improving how registry metadata is injected and used during CLI sync operations. The main change is that the CLI now fetches `skills/metadata.json` from the registry in-memory and injects it into the `IndexGeneratorService`, eliminating the need to write this file to disk. This enables more robust and secure index generation, especially for the router table in `AGENTS.md`. The PR also adds comprehensive tests for the new metadata injection logic and updates version numbers accordingly.

The most important changes are:

**Core functionality improvements:**

* Added a `withMetadata()` method to `IndexGeneratorService` that allows in-memory injection of registry metadata (`file_routing`, `broad_globs`, `base_language_skills`, `foundational_composite_rules`) for use during index generation, removing the need to read or write `metadata.json` from disk. [[1]](diffhunk://#diff-a3c25300e625945ae106ec8abe4988d5f21a72fc18357ea749d2a455fc03daf0R6-R17) [[2]](diffhunk://#diff-a3c25300e625945ae106ec8abe4988d5f21a72fc18357ea749d2a455fc03daf0R52-R72) [[3]](diffhunk://#diff-a3c25300e625945ae106ec8abe4988d5f21a72fc18357ea749d2a455fc03daf0L180-R214) [[4]](diffhunk://#diff-a3c25300e625945ae106ec8abe4988d5f21a72fc18357ea749d2a455fc03daf0L199-R240)
* Updated `SyncService` to fetch `skills/metadata.json` from the registry's default branch and inject it into the generator using `withMetadata()`, ensuring router table generation works even when no local metadata file exists.

**Testing and reliability:**

* Added extensive tests for the new metadata injection logic in `IndexGeneratorService` and `SyncService`, covering scenarios such as missing, malformed, or partial metadata, and ensuring that metadata is never written to disk. [[1]](diffhunk://#diff-4bfbf5030b87c87cd6882aa62b4cfd5d28917ce587eddc3f21d92931cb7649bcR743-R946) [[2]](diffhunk://#diff-78d885df696d7fcc54a6c2354a2ea5839aba77b2f2125ae30f2d6f121c8a7464R32) [[3]](diffhunk://#diff-78d885df696d7fcc54a6c2354a2ea5839aba77b2f2125ae30f2d6f121c8a7464R203) [[4]](diffhunk://#diff-78d885df696d7fcc54a6c2354a2ea5839aba77b2f2125ae30f2d6f121c8a7464R216-R365)

**Documentation and versioning:**

* Updated `CHANGELOG.md` to document the metadata sync fix and the new injection system, and bumped the CLI version to `2.1.1`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL8-R21) [[2]](diffhunk://#diff-088b5e0ac52dd36816ebc6b121d5423c763c3c18c098b91757c014937c7d632dL3-R3) [[3]](diffhunk://#diff-4e5d53b79780ec257e845296172b0e131f58a02e2203429882c5141c8af678ecL21-R21)

These changes ensure that hierarchical index sync is reliable and secure, and that the CLI can generate router tables without needing to persist registry metadata locally.…vice with metadata injection