### PR TITLE
Add registry sync warnings and enhance workflow configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the Programming Languages and Frameworks Agent Skills wil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [cli-v2.2.3] - 2026-05-10
+
+**Category**: 🔄 Workflow Sync Optimization & Registry Reliability
+
+### Fixed
+
+- **`WorkflowSyncService`**:
+  - **Preserved `workflows: true`**: Fixed a bug where setting `workflows: true` in `.skillsrc` was incorrectly overwritten by a fixed array of defaults. It now remains `true` to ensure automatic discovery of all future registry workflows.
+  - **Comprehensive Workflow Discovery**: Updated the CLI to include `dev-fix`, `implement-feature`, and `verify-bug` in the default synchronization list.
+  - **Enhanced Logging**: Added detailed status logs during the workflow assembly phase, including count of fetched files and warnings for empty registry matches.
+- **`SyncService`**:
+  - **Local Registry Detection**: Added a proactive warning when running `sync` within the registry repository itself, clarifying that the CLI pulls from the remote GitHub origin rather than local unpushed files.
+
+### Versions
+
+- **CLI**: `2.2.2` → `2.2.3`
+
 ## [mcp-v0.2.0] - 2026-05-09
 
 **Category**: 🚀 Transport Modernization & Security Hardening

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-standard",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "A CLI to manage and sync AI agent skills standard for Cursor, Claude, Copilot, Windsurf, and more.",
   "main": "dist/index.js",
   "bin": {

--- a/cli/src/constants/index.ts
+++ b/cli/src/constants/index.ts
@@ -81,6 +81,9 @@ export const DEFAULT_WORKFLOWS = [
   'plan-feature',
   'skill-benchmark',
   'pentest',
+  'dev-fix',
+  'implement-feature',
+  'verify-bug',
 ];
 
 // Configurable via ENV or hardcoded for production convenience

--- a/cli/src/services/GitService.ts
+++ b/cli/src/services/GitService.ts
@@ -103,4 +103,20 @@ export class GitService {
       return [];
     }
   }
+
+  /**
+   * Retrieves the URL of the 'origin' remote.
+   * @param rootDir The root directory of the repository
+   */
+  getRemoteUrl(rootDir: string): string | null {
+    try {
+      const output = execSync('git remote get-url origin', {
+        cwd: rootDir,
+        encoding: 'utf8',
+      });
+      return output.trim();
+    } catch {
+      return null;
+    }
+  }
 }

--- a/cli/src/services/SyncService.ts
+++ b/cli/src/services/SyncService.ts
@@ -12,6 +12,7 @@ import { IndexGeneratorServiceImpl } from './IndexGeneratorServiceImpl';
 import { SkillSyncService } from './SkillSyncService';
 import { WorkflowSyncService } from './WorkflowSyncService';
 import { SpecialistSyncService } from './SpecialistSyncService';
+import { GitService } from './GitService';
 import { MarkdownUtils } from './utils/MarkdownUtils';
 
 /**
@@ -26,6 +27,7 @@ export class SyncService {
   private skillSyncService = new SkillSyncService(this.githubService);
   private workflowSyncService = new WorkflowSyncService(this.githubService);
   private specialistSyncService = new SpecialistSyncService();
+  private gitService = new GitService();
 
   async reconcileConfig(
     config: SkillConfig,
@@ -53,7 +55,34 @@ export class SyncService {
     categories: string[],
     config: SkillConfig,
   ): Promise<CollectedSkill[]> {
+    await this.warnIfSyncingFromSameRepo(config);
     return this.skillSyncService.assembleSkills(categories, config);
+  }
+
+  private async warnIfSyncingFromSameRepo(config: SkillConfig) {
+    const remoteUrl = this.gitService.getRemoteUrl(process.cwd());
+    if (!remoteUrl) return;
+
+    const remoteMatch = GithubService.parseGitHubUrl(remoteUrl);
+    const registryMatch = GithubService.parseGitHubUrl(config.registry);
+
+    if (
+      remoteMatch &&
+      registryMatch &&
+      remoteMatch.owner === registryMatch.owner &&
+      remoteMatch.repo === registryMatch.repo
+    ) {
+      console.log(
+        pc.yellow(
+          `\n⚠️  Note: You are syncing from the registry repository itself (${remoteMatch.owner}/${remoteMatch.repo}).`,
+        ),
+      );
+      console.log(
+        pc.gray(
+          `   'ags sync' pulls from GitHub. If you have unpushed local changes, they will be overwritten by the remote versions.`,
+        ),
+      );
+    }
   }
 
   async writeSkills(

--- a/cli/src/services/WorkflowSyncService.ts
+++ b/cli/src/services/WorkflowSyncService.ts
@@ -56,7 +56,7 @@ export class WorkflowSyncService {
         );
         changed = true;
       }
-    } else if (config.workflows === undefined || config.workflows === true) {
+    } else if (config.workflows === undefined) {
       const defaultWorkflows = availableWorkflows.filter((wf) =>
         DEFAULT_WORKFLOWS.includes(wf),
       );
@@ -67,6 +67,19 @@ export class WorkflowSyncService {
         ),
       );
       changed = true;
+    } else if (config.workflows === true) {
+      // If it's true, we keep it true to sync everything from the registry.
+      // We don't overwrite it with the default list.
+      const newWorkflows = availableWorkflows.filter(
+        (wf) => !DEFAULT_WORKFLOWS.includes(wf),
+      );
+      if (newWorkflows.length > 0) {
+        console.log(
+          pc.cyan(
+            `ℹ️  Registry has ${availableWorkflows.length} workflows (including ${newWorkflows.length} non-default). Syncing all because 'workflows: true' is set.`,
+          ),
+        );
+      }
     }
 
     return changed;
@@ -121,6 +134,12 @@ export class WorkflowSyncService {
           })),
         },
       ];
+    } else {
+      if (workflowFiles.length > 0) {
+        console.log(pc.red(`    ❌ Failed to download ${workflowFiles.length} matched workflows.`));
+      } else {
+        console.log(pc.gray(`    ℹ️  No matching workflows found in registry.`));
+      }
     }
 
     return [];

--- a/cli/src/services/__tests__/WorkflowSyncService.spec.ts
+++ b/cli/src/services/__tests__/WorkflowSyncService.spec.ts
@@ -91,7 +91,25 @@ describe('WorkflowSyncService', () => {
       expect(result).toBe(false);
     });
 
-    it('should initialize workflows if undefined and true', async () => {
+    it('should initialize workflows to default array if undefined', async () => {
+      const config = {
+        registry: 'https://github.com/o/r',
+      } as unknown as SkillConfig;
+      mockGithubService.getRepoInfo.mockResolvedValue({
+        default_branch: 'main',
+      });
+      mockGithubService.getRepoTree.mockResolvedValue({
+        tree: [{ path: '.agents/workflows/code-review.md' }],
+      });
+
+      const result = await workflowSyncService.reconcileWorkflows(config);
+
+      expect(result).toBe(true);
+      expect(Array.isArray(config.workflows)).toBe(true);
+      expect(config.workflows).toContain('code-review');
+    });
+
+    it('should preserve workflows: true as a stable state', async () => {
       const config = {
         registry: 'https://github.com/o/r',
         workflows: true,
@@ -105,8 +123,8 @@ describe('WorkflowSyncService', () => {
 
       const result = await workflowSyncService.reconcileWorkflows(config);
 
-      expect(result).toBe(true);
-      expect(config.workflows).toEqual(['code-review']);
+      expect(result).toBe(false); // No change to .skillsrc
+      expect(config.workflows).toBe(true);
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-standard-root",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "private": true,
   "packageManager": "pnpm@10.0.0",
   "pnpm": {


### PR DESCRIPTION
This pull request focuses on improving the workflow synchronization process and enhancing reliability and clarity for users of the CLI. The main updates include preserving user configuration for workflow discovery, expanding the default workflow set, providing clearer logging and warnings, and updating the package version.

**Workflow synchronization improvements:**

* Fixed a bug in `WorkflowSyncService` so that setting `workflows: true` in `.skillsrc` is now preserved, ensuring all future registry workflows are automatically discovered instead of being overwritten by a fixed default list. [[1]](diffhunk://#diff-355bf4147d2707cee0d1a475a5c3839fb376f5b021591e69ca75771733d0a442L59-R59) [[2]](diffhunk://#diff-355bf4147d2707cee0d1a475a5c3839fb376f5b021591e69ca75771733d0a442R70-R82)
* Expanded the default workflow synchronization list to include `dev-fix`, `implement-feature`, and `verify-bug`, in addition to existing defaults.
* Added detailed logging during workflow assembly, including the number of fetched files and warnings for empty registry matches or failed downloads.

**Registry reliability and user warnings:**

* Added a proactive warning in `SyncService` when running `sync` inside the registry repository itself, clarifying that the CLI pulls from the remote GitHub origin and not local unpushed files. [[1]](diffhunk://#diff-412b92521f7d4b7a7100305b46fada0ae81d22755e991052cc981247d0f7f549R15) [[2]](diffhunk://#diff-412b92521f7d4b7a7100305b46fada0ae81d22755e991052cc981247d0f7f549R30) [[3]](diffhunk://#diff-88a16ecb22da8b0d4600add8b5d12ae8356cf756018f0c01f9b3de39bd5b456bR106-R121) [[4]](diffhunk://#diff-412b92521f7d4b7a7100305b46fada0ae81d22755e991052cc981247d0f7f549R58-R87)

**Version and documentation updates:**

* Bumped CLI and root package version to `2.2.3` and updated the changelog to reflect these workflow and reliability improvements. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R24) [[2]](diffhunk://#diff-088b5e0ac52dd36816ebc6b121d5423c763c3c18c098b91757c014937c7d632dL3-R3) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3)