### PR TITLE
fix(cli): preserve tools/model/color in Claude specialist frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Programming Languages and Frameworks Agent Skills wil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [cli-v2.6.1] - 2026-08-21
+
+**Category**: Claude specialist sync bug fix
+
+### Fixed
+
+- **Claude Specialist Frontmatter**: `SpecialistTransformer` now preserves `tools`, `model`, and `color` metadata from a specialist's `SKILL.md` frontmatter when generating `.claude/agents/*.md`, instead of silently dropping them ([#104](https://github.com/HoangNguyen0403/agent-skills-standard/issues/104)).
+
 ## [cli-v2.6.0] - 2026-07-14
 
 **Category**: Live eval evidence retention and report clarity

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-standard",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "A CLI to manage and sync AI agent skills standard for Cursor, Claude, Copilot, Windsurf, and more.",
   "main": "dist/index.js",
   "bin": {

--- a/cli/src/services/utils/SpecialistTransformer.ts
+++ b/cli/src/services/utils/SpecialistTransformer.ts
@@ -34,11 +34,21 @@ export class SpecialistTransformer {
       metadata.description || `Specialist persona for ${baseName}`;
 
     switch (agentId) {
-      case Agent.Claude:
+      case Agent.Claude: {
+        const fmLines = [`name: ${baseName}`, `description: "${description}"`];
+        if (metadata.tools) {
+          const tools = Array.isArray(metadata.tools)
+            ? metadata.tools.join(', ')
+            : metadata.tools;
+          fmLines.push(`tools: ${tools}`);
+        }
+        if (metadata.model) fmLines.push(`model: ${metadata.model}`);
+        if (metadata.color) fmLines.push(`color: ${metadata.color}`);
         return {
           name: `${baseName}.md`,
-          content: `---\nname: ${baseName}\ndescription: "${description}"\n---\n\n${body}`,
+          content: `---\n${fmLines.join('\n')}\n---\n\n${body}`,
         };
+      }
 
       case Agent.Cursor:
         return {

--- a/cli/src/services/utils/__tests__/SpecialistTransformer.spec.ts
+++ b/cli/src/services/utils/__tests__/SpecialistTransformer.spec.ts
@@ -23,6 +23,40 @@ Check OWASP.`,
     expect(result!.content).toContain('# Rules');
   });
 
+  it('should include tools/model/color in Claude frontmatter when present', () => {
+    const sourceWithMeta = {
+      name: 'specialist-security-reviewer',
+      content: `---
+name: specialist-security-reviewer
+description: "Review security"
+tools:
+  - Read
+  - Edit
+model: sonnet
+color: blue
+---
+# Rules
+Check OWASP.`,
+    };
+    const result = SpecialistTransformer.transform(sourceWithMeta, Agent.Claude);
+    expect(result).not.toBeNull();
+    const content = result!.content;
+    expect(content).toContain('tools: Read, Edit');
+    expect(content).toContain('model: sonnet');
+    expect(content).toContain('color: blue');
+    expect(content.indexOf('description:')).toBeLessThan(content.indexOf('tools:'));
+    expect(content.indexOf('tools:')).toBeLessThan(content.indexOf('model:'));
+    expect(content.indexOf('model:')).toBeLessThan(content.indexOf('color:'));
+  });
+
+  it('should omit tools/model/color from Claude frontmatter when absent', () => {
+    const result = SpecialistTransformer.transform(source, Agent.Claude);
+    expect(result).not.toBeNull();
+    expect(result!.content).not.toContain('tools:');
+    expect(result!.content).not.toContain('model:');
+    expect(result!.content).not.toContain('color:');
+  });
+
   it('should transform for Cursor (rule style)', () => {
     const result = SpecialistTransformer.transform(source, Agent.Cursor);
     expect(result).not.toBeNull();


### PR DESCRIPTION
## Summary
- `SpecialistTransformer`'s `Agent.Claude` case emitted only `name`/`description` in generated `.claude/agents/*.md` frontmatter, silently dropping `tools`, `model`, and `color` from specialist `SKILL.md` metadata.
- Now conditionally includes those fields (in `name` → `description` → `tools` → `model` → `color` order) when present, unchanged output when absent.
- Bumped `cli` to `2.6.1` and added a `CHANGELOG.md` entry (fix only, no publish tag pushed yet).

Fixes #104

## Test plan
- [x] `pnpm test` in `cli/` — 35 files / 784 tests pass, including 2 new cases (fields present / fields absent)
- [x] Verified existing Claude/Cursor/Copilot/fallback transform tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)