### PR TITLE
fix(cli): stop doubled/unescaped quotes in emitted workflow descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Claude Specialist Frontmatter**: `SpecialistTransformer` now preserves `tools`, `model`, and `color` metadata from a specialist's `SKILL.md` frontmatter when generating `.claude/agents/*.md`, instead of silently dropping them ([#104](https://github.com/HoangNguyen0403/agent-skills-standard/issues/104)).
 - **Doubled Quotes in Emitted Workflow Descriptions**: `WorkflowTransformer.parseSource()` now strips a matching surrounding-quote pair (`"..."` or `'...'`) from a workflow source's frontmatter `description` before it reaches format emitters. Previously, a quoted description (required when the value contains a `:`, e.g. `description: "Phase one: do the thing"`) was passed through with its quotes intact, and the TOML (Gemini CLI), Copilot prompt, and SKILL.md emitters re-wrapped it in a fresh pair of quotes, producing invalid doubled-quote output (`description: ""Phase one: do the thing""`) that failed to parse. Unquoted descriptions were unaffected. (#105)
+- **Unescaped Quotes in Copilot Prompt Descriptions**: `toCopilotPrompt` now escapes `\` and `"` in `description` before embedding it in frontmatter, matching the escaping already applied by the TOML and SKILL.md emitters. Previously an internal `"` in an unquoted description could break the emitted `.prompt.md` frontmatter.
 
 ## [cli-v2.6.0] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [cli-v2.6.1] - 2026-08-21
 
-**Category**: Claude specialist sync bug fix
+**Category**: Sync-format bug fixes
 
 ### Fixed
 
 - **Claude Specialist Frontmatter**: `SpecialistTransformer` now preserves `tools`, `model`, and `color` metadata from a specialist's `SKILL.md` frontmatter when generating `.claude/agents/*.md`, instead of silently dropping them ([#104](https://github.com/HoangNguyen0403/agent-skills-standard/issues/104)).
+- **Doubled Quotes in Emitted Workflow Descriptions**: `WorkflowTransformer.parseSource()` now strips a matching surrounding-quote pair (`"..."` or `'...'`) from a workflow source's frontmatter `description` before it reaches format emitters. Previously, a quoted description (required when the value contains a `:`, e.g. `description: "Phase one: do the thing"`) was passed through with its quotes intact, and the TOML (Gemini CLI), Copilot prompt, and SKILL.md emitters re-wrapped it in a fresh pair of quotes, producing invalid doubled-quote output (`description: ""Phase one: do the thing""`) that failed to parse. Unquoted descriptions were unaffected. (#105)
 
 ## [cli-v2.6.0] - 2026-07-14
 

--- a/cli/src/services/utils/WorkflowTransformer.ts
+++ b/cli/src/services/utils/WorkflowTransformer.ts
@@ -113,8 +113,14 @@ export class WorkflowTransformer {
     if (!match) return { description: '', body: content };
 
     const descMatch = match[1].match(/description:\s*(.+)/);
+    const rawDescription = descMatch ? descMatch[1].trim() : '';
+    const quotedMatch = rawDescription.match(/^"(.*)"$|^'(.*)'$/);
+    const description = quotedMatch
+      ? (quotedMatch[1] ?? quotedMatch[2])
+      : rawDescription;
+
     return {
-      description: descMatch ? descMatch[1].trim() : '',
+      description,
       body: match[2],
     };
   }

--- a/cli/src/services/utils/WorkflowTransformer.ts
+++ b/cli/src/services/utils/WorkflowTransformer.ts
@@ -186,7 +186,10 @@ ${escapedBody}
    * User invokes via /prompt-name in Copilot chat.
    */
   private static toCopilotPrompt(description: string, body: string): string {
-    return `---\ndescription: "${description}"\n---\n${body}`;
+    const escapedDescription = description
+      .replace(/\\/g, '\\\\')
+      .replace(/"/g, '\\"');
+    return `---\ndescription: "${escapedDescription}"\n---\n${body}`;
   }
 
   /**

--- a/cli/src/services/utils/__tests__/WorkflowTransformer.spec.ts
+++ b/cli/src/services/utils/__tests__/WorkflowTransformer.spec.ts
@@ -241,6 +241,75 @@ describe('WorkflowTransformer', () => {
     });
   });
 
+  describe('quoted frontmatter description (issue #105)', () => {
+    it('strips a matching double-quoted pair when parsing', () => {
+      const source = {
+        name: 'test.md',
+        content:
+          '---\ndescription: "Phase one: do the thing"\n---\n# Test',
+      };
+      const parsed = WorkflowTransformer.parse(source);
+      expect(parsed.description).toBe('Phase one: do the thing');
+    });
+
+    it('strips a matching single-quoted pair when parsing', () => {
+      const source = {
+        name: 'test.md',
+        content: "---\ndescription: 'Phase one: do the thing'\n---\n# Test",
+      };
+      const parsed = WorkflowTransformer.parse(source);
+      expect(parsed.description).toBe('Phase one: do the thing');
+    });
+
+    it('does not double-quote a double-quoted description in toml format', () => {
+      const source = {
+        name: 'test.md',
+        content:
+          '---\ndescription: "Phase one: do the thing"\n---\n# Test',
+      };
+      const result = WorkflowTransformer.transform(source, 'toml');
+      expect(result!.content).toContain(
+        'description = "Phase one: do the thing"',
+      );
+      expect(result!.content).not.toContain('""Phase');
+    });
+
+    it('does not double-quote a double-quoted description in prompt format', () => {
+      const source = {
+        name: 'test.md',
+        content:
+          '---\ndescription: "Phase one: do the thing"\n---\n# Test',
+      };
+      const result = WorkflowTransformer.transform(source, 'prompt');
+      expect(result!.content).toContain(
+        'description: "Phase one: do the thing"',
+      );
+      expect(result!.content).not.toContain('""');
+    });
+
+    it('does not double-quote a double-quoted description in skill format', () => {
+      const source = {
+        name: 'test.md',
+        content:
+          '---\ndescription: "Phase one: do the thing"\n---\n# Test',
+      };
+      const result = WorkflowTransformer.transform(source, 'skill');
+      expect(result!.content).toContain(
+        'description: "Phase one: do the thing"',
+      );
+      expect(result!.content).not.toContain('""');
+    });
+
+    it('leaves an unmatched leading quote alone', () => {
+      const source = {
+        name: 'test.md',
+        content: '---\ndescription: "Quote at start only\n---\n# Test',
+      };
+      const parsed = WorkflowTransformer.parse(source);
+      expect(parsed.description).toBe('"Quote at start only');
+    });
+  });
+
   describe('WorkflowTransformer - Additional Branch Coverage', () => {
     it('handles frontmatter without description', () => {
       const source = {

--- a/cli/src/services/utils/__tests__/WorkflowTransformer.spec.ts
+++ b/cli/src/services/utils/__tests__/WorkflowTransformer.spec.ts
@@ -180,6 +180,18 @@ describe('WorkflowTransformer', () => {
       expect(result!.content).toContain('## Step 1');
       expect(result!.content).toContain('git diff');
     });
+
+    it('should escape quotes and backslashes in description', () => {
+      const quoted = {
+        name: 'test.md',
+        content:
+          '---\ndescription: Use "strict" mode and \\ escape.\n---\n# Test',
+      };
+      const result = WorkflowTransformer.transform(quoted, 'prompt');
+      expect(result!.content).toContain(
+        'description: "Use \\"strict\\" mode and \\\\ escape."',
+      );
+    });
   });
 
   it('should handle content without frontmatter', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-skills-standard-root",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "private": true,
   "packageManager": "pnpm@10.0.0",
   "pnpm": {


### PR DESCRIPTION
## Summary

- `WorkflowTransformer.parseSource()` kept surrounding quotes from a source frontmatter `description` intact. Quoting is required whenever the value contains a `:` (e.g. `description: "Phase one: do the thing"`). Downstream emitters (TOML/Gemini, Copilot prompt, SKILL.md) then re-wrapped the already-quoted value in a fresh pair of quotes, producing invalid doubled-quote output. Fixed by stripping one matching outer quote pair (`"..."` or `'...'`) in `parseSource()`.
- Also fixed a related gap flagged during investigation: `toCopilotPrompt` embedded `description` into frontmatter with **no escaping** at all (unlike the TOML/SKILL.md emitters), so an internal `"` in an unquoted description could also break the emitted `.prompt.md`. Now escapes `\` and `"` consistently with the other emitters.
- Bumped `cli` (and root) package version to `2.6.1` and added a `CHANGELOG.md` entry.

Fixes #105

## Test plan

- [x] `pnpm test` in `cli/` — 789/789 pass, including new cases for double/single-quoted descriptions across all quoting emitters (toml/prompt/skill), an unmatched-lone-quote edge case, and Copilot prompt escaping
- [x] Existing wrapper-parity test (round-trips through `js-yaml`) still passes
- [x] `pnpm build` in `cli/` succeeds with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)